### PR TITLE
feat: don't render package selector if only one package

### DIFF
--- a/ui/components/PackageSelect.jsx
+++ b/ui/components/PackageSelect.jsx
@@ -16,18 +16,19 @@ const PackageSelect = ({
   selectedPackageName,
   packageNames,
   onSelectPackage,
-}) => (
-  <StyledSelect
-    className={className}
-    clearable={false}
-    value={selectedPackageName}
-    onChange={selectedOption => onSelectPackage(selectedOption.value)}
-    options={packageNames.map(name => ({
-      value: name,
-      label: name || '<anonymous>',
-    }))}
-  />
-);
+}) =>
+  packageNames.length > 1 && (
+    <StyledSelect
+      className={className}
+      clearable={false}
+      value={selectedPackageName}
+      onChange={selectedOption => onSelectPackage(selectedOption.value)}
+      options={packageNames.map(name => ({
+        value: name,
+        label: name || '<anonymous>',
+      }))}
+    />
+  );
 
 PackageSelect.propTypes = {
   className: PropTypes.string,


### PR DESCRIPTION
<!--

Thanks for your pull request! 🎊

-->

## Checklist

* [x] tests pass (`yarn test; yarn lint`)
* [x] I'm in `all-contributors` <!-- yarn all-contributors add myself what,i,did -->

# What's changed?

<!--

Go in detail about which parts are changed and why these changes are done

-->

if not in a monorepo, there's no package picker rendered

## Test plan

<!--

Explain how to test that this PR works as intended

-->

no selector rendered in single repo, shown in monorepo
