### PR TITLE
feat(terminal): use accessible colors

### DIFF
--- a/ui/components/terminal.css
+++ b/ui/components/terminal.css
@@ -2,47 +2,47 @@
   color: black;
 }
 .ansi-fg-red {
-  color: red;
+  color: #cf3029;
 }
 .ansi-fg-green {
-  color: green;
+  color: #00ba3f;
 }
 .ansi-fg-yellow {
-  color: yellow;
+  color: #949900;
 }
 .ansi-fg-blue {
-  color: blue;
+  color: #004ea8;
 }
 .ansi-fg-magenta {
-  color: magenta;
+  color: #be00be;
 }
 .ansi-fg-cyan {
-  color: cyan;
+  color: #0098be;
 }
 .ansi-fg-white {
-  color: white;
+  color: #555554;
 }
 .ansi-bg-black {
   background-color: black;
 }
 .ansi-bg-red {
-  background-color: red;
+  background-color: #cf3029;
 }
 .ansi-bg-green {
-  background-color: green;
+  background-color: #00ba3f;
 }
 .ansi-bg-yellow {
-  background-color: yellow;
+  background-color: #949900;
 }
 .ansi-bg-blue {
-  background-color: blue;
+  background-color: #004ea8;
 }
 .ansi-bg-magenta {
-  background-color: magenta;
+  background-color: #be00be;
 }
 .ansi-bg-cyan {
-  background-color: cyan;
+  background-color: #0098be;
 }
 .ansi-bg-white {
-  background-color: white;
+  background-color: #555554;
 }


### PR DESCRIPTION
fixes #39

<!--

Thanks for your pull request! 🎊

-->

## Checklist

* [x] tests pass (`yarn test; yarn lint`)
* [x] I'm in `all-contributors` <!-- yarn all-contributors add myself what,i,did -->

# What's changed?

<!--

Go in detail about which parts are changed and why these changes are done

-->

made the colours accessible (using the same colours as the light color scheme I use in my editor)

## Test plan

<!--

Explain how to test that this PR works as intended

-->

run the `rainbow` script and make sure you can read it (especially the white background ones)